### PR TITLE
og:title / og:url 追加

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,6 +7,9 @@
   {{ else }}
     <title>{{ .Title }} &middot; {{ .Site.Title }}</title>
   {{ end }}
+  <meta property="og:title" content="{{ .Title }}">
+  <meta property="og:description" content="{{ .Summary }}">
+  <meta property="og:url" content="{{ .Permalink }}">
   <meta property="og:image" content="http://blog.monochromegane.com/images/ogp.png">
   <!-- Stylesheets -->
   <link rel="stylesheet" href="/css/reset.css">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,7 +8,6 @@
     <title>{{ .Title }} &middot; {{ .Site.Title }}</title>
   {{ end }}
   <meta property="og:title" content="{{ .Title }}">
-  <meta property="og:description" content="{{ .Summary }}">
   <meta property="og:url" content="{{ .Permalink }}">
   <meta property="og:image" content="http://blog.monochromegane.com/images/ogp.png">
   <!-- Stylesheets -->


### PR DESCRIPTION
ref https://github.com/monochromegane/hugo-theme-thinking-megane/issues/2

Slack等、タイトルが表示されず内容がわからない状況になってしまうため `og:image` 以外も追加する。
`og:description` は内容によってはhtmlタグが出力され崩れの原因となるため今は設定しない。
#### evidence
- [記事個別ページごとの内容に差し代わる](https://cloud.githubusercontent.com/assets/1661325/8696146/f48122fe-2b24-11e5-8e7b-e24ad3bce23d.png)
- [タグが混入することはないので、崩れない](https://cloud.githubusercontent.com/assets/1661325/8696157/0342326a-2b25-11e5-93b2-67332d783689.png)
