### PR TITLE
Add table css

### DIFF
--- a/static/css/color.css
+++ b/static/css/color.css
@@ -57,6 +57,23 @@ hr {
   background-color: #29292f;
 }
 
+table {
+  border-color: #dfdfdf;
+  background: #fff;
+}
+
+th,td {
+  border-color: #dfdfdf;
+}
+
+td {
+  background-color: #fff;
+}
+
+tr:nth-child(even) td {
+  background-color: #fcfcff;
+}
+
 .tag {
   color: #9e9e9e;
   border-bottom: 1px solid #ededed;

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -131,6 +131,35 @@ hr {
   margin: 2em 0;
 }
 
+table {
+  margin: 1.5em 0;
+  border-collapse: collapse;
+  border-spacing: 0;
+  border-style: solid;
+  border-width: 1px 0 0 1px;
+}
+
+@media screen and (max-width: 538px) {
+  table {
+    font-size: .8em;
+  }
+}
+
+th,td {
+  padding: 10px 15px;
+  border-style: solid;
+  border-width: 0 1px 1px 0;
+}
+
+th {
+  border-bottom: 2px solid #52545a;
+}
+
+td {
+  line-height: 180%;
+  font-size: 15px;
+}
+
 .tag {
   margin-top: 1em;
   padding: 17px 0;

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -149,6 +149,7 @@ th,td {
   padding: 10px 15px;
   border-style: solid;
   border-width: 0 1px 1px 0;
+  word-break: break-all;
 }
 
 th {
@@ -157,7 +158,6 @@ th {
 
 td {
   line-height: 180%;
-  font-size: 15px;
 }
 
 .tag {


### PR DESCRIPTION
お待たせしました。 `table` のスタイルを追加しました :information_desk_person:

![image](https://cloud.githubusercontent.com/assets/1661325/11847866/ccbf53d2-a462-11e5-97f4-9fc4e56c63dc.png)
## Smartphone

`長めのアルファベット` や `長文` を挿入された場合でも、スマホで見ても横スクロールが発生してしまう、ブログテンプレートが崩れてしまう、などといった状況は発生しません。

| 長めのアルファベット | 長文 |
| --- | --- |
| ![image](https://cloud.githubusercontent.com/assets/1661325/11847507/3db5baa6-a461-11e5-8726-0d78e81d1587.png) | ![image](https://cloud.githubusercontent.com/assets/1661325/11847554/5ff71862-a461-11e5-866e-6eb7b51da33b.png) |
